### PR TITLE
[SECURITY-17884] WASP Onboarding - freshdesk/action-rubocop

### DIFF
--- a/.github/workflows/security.yaml.j2
+++ b/.github/workflows/security.yaml.j2
@@ -1,0 +1,52 @@
+# Remove any comment lines that are not necessary
+
+name: Wasp (Semgrep) - SAST Check
+
+on:
+  pull_request_target:
+    branches:
+      - "master" # This will be the default branch of a repo
+  schedule:
+    - cron: '0 */24 * * *' # Run everyday at 12 AM UTC
+  workflow_dispatch: # Run on demand
+
+jobs:
+  wasp-scan:
+    name: Wasp scan
+    runs-on: ["self-hosted", "Linux", "fw-shared"]
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+
+      - name: Running Wasp scan
+        uses: freshactions/wasp@latest
+        env:
+          # Remove any of the following environment variables if you don't want to use them.
+          WASP_LOG_LEVEL: DEBUG
+          WASP_SAVE_JSON: true
+          WASP_SAVE_HTML: true
+          WASP_SAVE_CSV: true
+          WASP_FRESHRELEASE_PR_PROJECT_KEY: "FSALES"
+          # Dry run will not raise any tickets. Remove this if you don't want to run in dry run mode.
+          
+          WASP_DRY_RUN: ${{ vars.SECURITY_APPSEC_WASP_DRY_RUN }}
+
+          WASP_FRESHRELEASE_URL: ${{ vars.SECURITY_APPSEC_FRESHRELEASE_URL }}
+          WASP_FRESHRELEASE_PR_ISSUE_TYPE: ${{ vars.SECURITY_APPSEC_FRESHRELEASE_PR_ISSUE_TYPE }}          
+
+          WASP_PULSE_URL: ${{ secrets.WASP_PULSE_URL }}
+          WASP_TOKEN: ${{ secrets.SECURITY_APPSEC_WASP_TOKEN }}
+          WASP_FRESHRELEASE_TOKEN: ${{ secrets.SECURITY_APPSEC_FRESHRELEASE_TOKEN }}
+          WASP_SLACK_TOKEN: ${{ secrets.SECURITY_APPSEC_SLACK_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SECURITY_APPSEC_GH_TOKEN }}
+          
+      # Use this step to upload the scan report as an artifact.
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Wasp scan report archive
+          retention-days: 90
+          path: |
+            wasp-report.csv
+            wasp-report.json
+            wasp-report.html


### PR DESCRIPTION
This PR adds SAST security checks as a workflow in GitHub actions.

The workflow adds a scheduled scan every 24 hours at 12 am, a manual trigger, and also runs for pull requests raised to the default branch of the repo.

Please let us know if you want the pull request scan to run for a different branch.

Note: You need to add wasp-scan in required checks under branch protection so that the scan can block PRs if issues are found. Please refer to this [link](https://confluence.freshworks.com/display/SEC/Adding+Wasp+as+a+check+in+Pull+Requests)

https://confluence.freshworks.com/display/SEC/Semgrep

Please review the workflow and let us know if you want to add or remove anything. Please let us know if you want to ignore any files or folder paths in the scans. This can be added via the environment variables or a file named .semgrepignore.
